### PR TITLE
fix(workflow): resolve shell syntax error in PR validation

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -21,7 +21,8 @@ jobs:
           echo "Head Branch: ${{ github.event.pull_request.head.ref }}"
           
           # Check if PR references an issue
-          if echo "${{ github.event.pull_request.body }}" | grep -q "#[0-9]"; then
+          PR_BODY="${{ github.event.pull_request.body }}"
+          if echo "$PR_BODY" | grep -q "#[0-9]"; then
             echo "✅ PR references an issue"
           else
             echo "❌ PR doesn't reference an issue - this is required"
@@ -29,7 +30,7 @@ jobs:
           fi
           
           # Check if PR has a description
-          if [ -n "${{ github.event.pull_request.body }}" ]; then
+          if [ -n "$PR_BODY" ]; then
             echo "✅ PR has a description"
           else
             echo "❌ PR description is empty - this is required"
@@ -37,10 +38,11 @@ jobs:
           fi
           
           # Check if PR title follows convention
-          if echo "${{ github.event.pull_request.title }}" | grep -qE "^(feat|fix|docs|style|refactor|test|chore|security):"; then
+          PR_TITLE="${{ github.event.pull_request.title }}"
+          if echo "$PR_TITLE" | grep -qE "^(feat|fix|docs|style|refactor|test|chore|security):"; then
             echo "✅ PR title follows conventional commit format"
           else
-            echo "⚠️ PR title doesn't follow conventional commit format (feat:, fix:, etc.)"
+            echo "⚠️ PR title doesn't follow conventional commit format"
           fi
 
       - name: Run Security Checks

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -14,11 +14,17 @@ jobs:
 
       - name: Validate PR Requirements
         run: |
-          echo "🔍 Validating Pull Request #${{ github.event.number }}"
-          echo "PR Title: ${{ github.event.pull_request.title }}"
-          echo "PR Author: ${{ github.event.pull_request.user.login }}"
-          echo "Base Branch: ${{ github.event.pull_request.base.ref }}"
-          echo "Head Branch: ${{ github.event.pull_request.head.ref }}"
+          PR_NUMBER="${{ github.event.number }}"
+          PR_TITLE="${{ github.event.pull_request.title }}"
+          PR_AUTHOR="${{ github.event.pull_request.user.login }}"
+          BASE_BRANCH="${{ github.event.pull_request.base.ref }}"
+          HEAD_BRANCH="${{ github.event.pull_request.head.ref }}"
+          
+          echo "🔍 Validating Pull Request #$PR_NUMBER"
+          echo "PR Title: $PR_TITLE"
+          echo "PR Author: $PR_AUTHOR"
+          echo "Base Branch: $BASE_BRANCH"
+          echo "Head Branch: $HEAD_BRANCH"
           
           # Check if PR references an issue
           PR_BODY="${{ github.event.pull_request.body }}"
@@ -38,7 +44,6 @@ jobs:
           fi
           
           # Check if PR title follows convention
-          PR_TITLE="${{ github.event.pull_request.title }}"
           if echo "$PR_TITLE" | grep -qE "^(feat|fix|docs|style|refactor|test|chore|security):"; then
             echo "✅ PR title follows conventional commit format"
           else

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "toginnsikt-dashboard"]
+	path = toginnsikt-dashboard
+	url = https://github.com/haakonstillingen/toginnsikt-dashboard.git
+	branch = main


### PR DESCRIPTION
## Summary

This PR fixes the shell syntax error in the PR validation workflow that was causing failures when PR titles contain special characters like parentheses.

## Problem

The PR validation workflow was failing with syntax errors when PR titles contained special characters (e.g., parentheses in 'feat(dashboard): ...'). This was because GitHub context variables were being expanded directly in shell commands, causing parsing issues.

## Solution

- Store GitHub context variables in shell variables first to avoid syntax errors
- Use shell variables instead of direct GitHub context expansion
- Prevents special characters in PR titles from causing shell script failures

## Changes Made

- **Updated PR validation workflow** to use shell variables for GitHub context
- **Fixed syntax error** that occurred with parentheses in PR titles
- **Maintained all existing validation logic** (issue references, descriptions, etc.)

## Testing

- Workflow should now pass validation for PRs with special characters in titles
- All existing validation checks remain intact
- No breaking changes to validation logic

## Related

- Fixes PR validation failures in #24
- Enables proper validation for conventional commit format PRs

Fixes workflow validation issues