### PR TITLE
fix(collector): add route pattern validation to prevent wrong destination collection

### DIFF
--- a/enhanced_commute_collector_cloud.py
+++ b/enhanced_commute_collector_cloud.py
@@ -176,7 +176,7 @@ class EnhancedCommuteCollectorCloud:
             conn.close()
         
     def load_commute_routes(self) -> List[CommuteRoute]:
-        """Load commute routes from database"""
+        """Load commute routes from database with validation"""
         conn = self.get_db_connection()
         if not conn:
             return []
@@ -185,22 +185,66 @@ class EnhancedCommuteCollectorCloud:
         
         try:
             cursor.execute("""
-                SELECT route_name, source_station_id, source_station_name, 
+                SELECT id, route_name, source_station_id, source_station_name, 
                        target_station_id, target_station_name, final_destination_pattern, direction
                 FROM commute_routes
+                ORDER BY id
             """)
             
             routes = []
+            seen_routes = set()  # Track using (source, target, direction) to detect duplicates
+            
             for row in cursor.fetchall():
-                routes.append(CommuteRoute(
-                    route_name=row[0],
-                    source_station_id=row[1],
-                    source_station_name=row[2],
-                    target_station_id=row[3],
-                    target_station_name=row[4],
-                    final_destination_pattern=row[5],
-                    direction=row[6]
-                ))
+                route_id = row[0]
+                route_name = row[1]
+                source_station_id = row[2]
+                source_station_name = row[3]
+                target_station_id = row[4]
+                target_station_name = row[5]
+                final_destination_pattern = row[6]
+                direction = row[7]
+                
+                # Validate route has required pattern
+                if not final_destination_pattern or final_destination_pattern.strip() == '':
+                    self.logger.warning(
+                        f"Skipping route {route_id} ({route_name}): "
+                        f"Missing or empty final_destination_pattern. "
+                        f"This route will not collect any departures."
+                    )
+                    continue
+                
+                # Check for duplicate route definitions using direction instead of route_name
+                # This ensures only ONE morning and ONE afternoon route per station pair
+                route_key = (source_station_id, target_station_id, direction)
+                if route_key in seen_routes:
+                    self.logger.warning(
+                        f"Skipping duplicate route {route_id} ({route_name}): "
+                        f"{source_station_name} → {target_station_name} ({direction})"
+                    )
+                    continue
+                
+                seen_routes.add(route_key)
+                
+                route = CommuteRoute(
+                    route_name=route_name,
+                    source_station_id=source_station_id,
+                    source_station_name=source_station_name,
+                    target_station_id=target_station_id,
+                    target_station_name=target_station_name,
+                    final_destination_pattern=final_destination_pattern,
+                    direction=direction
+                )
+                
+                routes.append(route)
+                self.logger.info(
+                    f"Loaded route: {route_name} ({source_station_name} → {target_station_name}), "
+                    f"Pattern: '{final_destination_pattern}', Direction: {direction}"
+                )
+            
+            if not routes:
+                self.logger.error("No valid routes loaded from database!")
+            else:
+                self.logger.info(f"Successfully loaded {len(routes)} valid route(s)")
             
             return routes
         except Exception as e:
@@ -319,8 +363,21 @@ class EnhancedCommuteCollectorCloud:
             # Get final destination
             final_destination = call.get('destinationDisplay', {}).get('frontText', '')
             
-            # Check if this matches our route's final destination pattern (skip if pattern is empty)
-            if route.final_destination_pattern and not self.matches_final_destination(final_destination, route.final_destination_pattern):
+            # Check if this matches our route's final destination pattern
+            # Pattern should always be present due to validation in load_commute_routes()
+            if not route.final_destination_pattern:
+                self.logger.error(
+                    f"Route {route.route_name} has no pattern - this should not happen! "
+                    f"Skipping departure to {final_destination}"
+                )
+                continue
+            
+            if not self.matches_final_destination(final_destination, route.final_destination_pattern):
+                self.logger.debug(
+                    f"Skipping departure to '{final_destination}' - "
+                    f"does not match pattern '{route.final_destination_pattern}' "
+                    f"for route {route.route_name}"
+                )
                 continue
                 
             planned_departures.append(PlannedDeparture(
@@ -334,10 +391,12 @@ class EnhancedCommuteCollectorCloud:
         return planned_departures
 
     def matches_final_destination(self, destination: str, pattern: str) -> bool:
-        """Check if destination matches the route's final destination pattern"""
-        # Convert pattern to regex (e.g., "Lysaker|Stabekk" becomes "Lysaker|Stabekk")
-        pattern_regex = pattern.replace('|', '|')
-        return bool(re.search(pattern_regex, destination, re.IGNORECASE))
+        """Check if destination matches the route's final destination pattern
+        
+        Pattern uses pipe (|) as regex alternation operator for multiple destinations.
+        Example: "Lysaker|Stabekk" matches trains going to either Lysaker or Stabekk.
+        """
+        return bool(re.search(pattern, destination, re.IGNORECASE))
 
     def get_collection_frequency(self) -> int:
         """Get collection frequency in minutes based on current time"""


### PR DESCRIPTION
## Problem
Routes without `final_destination_pattern` were bypassing destination filtering, causing incorrect trains to be collected. For example, routes with empty patterns allowed 'Ski' trains to be collected on routes that should only collect 'Lysaker/Stabekk' trains.

## Changes
- ✅ Add validation to skip routes with empty `final_destination_pattern`
- ✅ Detect and skip duplicate route definitions using `(source, target, direction)` key
  - Uses `direction` instead of `route_name` to ensure only ONE morning/afternoon route per station pair
- ✅ Add comprehensive logging for route loading and filtering operations
- ✅ Improve pattern matching error handling in `fetch_planned_departures()`
- ✅ Remove no-op string replace in `matches_final_destination()`
- ✅ Add documentation for regex pattern matching behavior

## Impact
- Prevents collection of incorrect departure data
- Protects both Morning Commute and Afternoon Commute routes
- Routes without valid patterns will be logged and skipped
- Duplicate routes will be detected and rejected

## Testing
- No linter errors
- Single focused commit following conventional commit format
- Changes are defensive and fail-safe

## Improvements over PR #28
This PR addresses all the issues identified in the review of PR #28:
- ✅ Single concern: Only the bug fix, no investigation scripts or data cleanup
- ✅ Clean commit history: One well-formatted commit
- ✅ Improved duplicate detection: Uses `direction` instead of `route_name`
- ✅ Removed no-op code: Fixed `matches_final_destination()` method
- ✅ Better documentation: Added docstring explaining regex pattern behavior

Fixes #29